### PR TITLE
refactor: derive image storage path from runtime

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -23,11 +23,11 @@ import (
 )
 
 const (
-	path            = "C:/Users/ADerkach/Desktop/go-rabbit-image/"
-	image_folder    = "/server_images"
-	rabbitURL       = "amqp://guest:guest@localhost:5672/"
-	queueName       = "Queue"
-	timeoutDuration = time.Second * 5
+	imageFolder           = "server_images"
+	rabbitURL             = "amqp://guest:guest@localhost:5672/"
+	queueName             = "Queue"
+	timeoutDuration       = time.Second * 5
+	imageStorageRootEnvID = "IMAGE_STORAGE_ROOT"
 )
 
 type App struct {
@@ -56,7 +56,15 @@ func New(log logger.Logger) (*App, error) {
 
 	// It creates a file storage repository and
 	// an associated file service, logging any errors that occur.
-	pathToServerFiles := filepath.Join(path, image_folder)
+	storageRootPath, err := resolveImageStorageRoot()
+	if err != nil {
+		log.Error("Can't determine image storage root", logger.M{
+			"error": err,
+		})
+		return nil, fmt.Errorf("can't determine image storage root: %w", err)
+	}
+
+	pathToServerFiles := filepath.Join(storageRootPath, imageFolder)
 	fileStorage, err := repository.New(pathToServerFiles, log)
 	if err != nil {
 		log.Error("Can't create file storage", logger.M{
@@ -166,4 +174,18 @@ func (a *App) WaitForShutdown() {
 	a.log.Info("Got signal for terminating server", logger.M{
 		"signal": sig,
 	})
+}
+
+func resolveImageStorageRoot() (string, error) {
+	storageRoot := os.Getenv(imageStorageRootEnvID)
+	if storageRoot != "" {
+		return storageRoot, nil
+	}
+
+	storageRoot, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("get working directory: %w", err)
+	}
+
+	return storageRoot, nil
 }

--- a/internal/infrastructure/file/repository/local_test.go
+++ b/internal/infrastructure/file/repository/local_test.go
@@ -1,0 +1,69 @@
+package repository
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/andrsj/go-rabbit-image/pkg/logger"
+)
+
+type noopLogger struct{}
+
+func (l noopLogger) Named(string) logger.Logger { return l }
+func (noopLogger) Debug(string, logger.M)       {}
+func (noopLogger) Info(string, logger.M)        {}
+func (noopLogger) Warn(string, logger.M)        {}
+func (noopLogger) Error(string, logger.M)       {}
+func (noopLogger) Fatal(string, logger.M)       {}
+
+var png1x1 = []byte{
+	0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a,
+	0x00, 0x00, 0x00, 0x0d, 0x49, 0x48, 0x44, 0x52,
+	0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+	0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+	0xde, 0x00, 0x00, 0x00, 0x0b, 0x49, 0x44, 0x41,
+	0x54, 0x08, 0xd7, 0x63, 0xf8, 0xcf, 0xc0, 0x00,
+	0x00, 0x04, 0x00, 0x01, 0xe2, 0x26, 0x05, 0x9b,
+	0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4e, 0x44,
+	0xae, 0x42, 0x60, 0x82,
+}
+
+func TestNewCreatesDirectory(t *testing.T) {
+	t.Parallel()
+
+	baseDir := filepath.Join(t.TempDir(), "server_images")
+	if _, err := New(baseDir, noopLogger{}); err != nil {
+		t.Fatalf("expected no error creating repository: %v", err)
+	}
+
+	if info, err := os.Stat(baseDir); err != nil {
+		t.Fatalf("expected directory to be created: %v", err)
+	} else if !info.IsDir() {
+		t.Fatalf("expected %s to be a directory", baseDir)
+	}
+}
+
+func TestCreateImageCreatesFile(t *testing.T) {
+	t.Parallel()
+
+	baseDir := filepath.Join(t.TempDir(), "server_images")
+	repo, err := New(baseDir, noopLogger{})
+	if err != nil {
+		t.Fatalf("expected no error creating repository: %v", err)
+	}
+
+	const (
+		imageID = "test-image"
+		level   = "75"
+	)
+
+	if err := repo.CreateImage(png1x1, imageID, level); err != nil {
+		t.Fatalf("expected no error creating image: %v", err)
+	}
+
+	expectedPath := filepath.Join(baseDir, imageID, level+".png")
+	if _, err := os.Stat(expectedPath); err != nil {
+		t.Fatalf("expected image file to exist: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- derive the image storage root from an environment variable or working directory instead of a hard-coded path
- ensure the server image folder joins correctly without a leading slash
- add repository tests that confirm directories and files can be created under the configured storage root

## Testing
- `go test ./internal/infrastructure/file/repository`


------
https://chatgpt.com/codex/tasks/task_e_68ce390c6e748332817c8882eb3a0497