### PR TITLE
Return bad request response when form file retrieval fails

### DIFF
--- a/internal/delivery/http/rest/api/post.go
+++ b/internal/delivery/http/rest/api/post.go
@@ -16,6 +16,10 @@ func (a *api) PublishImage(ctx *gin.Context) {
 	file, err := ctx.FormFile("image")
 	if err != nil {
 		a.logger.Error("Can't get image from form data", logger.M{"error": err})
+		ctx.AbortWithStatusJSON(
+			http.StatusBadRequest,
+			gin.H{"error": fmt.Sprintf("Can't get image from form data: %s", err)},
+		)
 
 		return
 	}


### PR DESCRIPTION
## Summary
- return an explicit 400 Bad Request JSON payload when retrieving the uploaded image from the form fails

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68ce3ac6a9c88332a31f5823d649b475